### PR TITLE
  feat: add multi-select metadata retrieval and deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
                     "when": "salesforce-migrator.isSfdxProject"
                 },
                 {
+                    "id": "salesforce-migrator.metadata-selection",
+                    "name": "Selected Metadata",
+                    "icon": "/images/view.svg",
+                    "type": "webview",
+                    "when": "salesforce-migrator.isSfdxProject"
+                },
+                {
                     "id": "salesforce-migrator.records-selector",
                     "name": "Records",
                     "icon": "/images/view.svg",

--- a/resources/css/metadataDeploymentWebview.css
+++ b/resources/css/metadataDeploymentWebview.css
@@ -43,10 +43,11 @@ button:active {
 /* Responsive table styles */
 table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 0;
   padding: 0;
-  border: 0.0625rem solid var(--vscode-panel-border);
+  border: 1px solid var(--vscode-panel-border);
   border-radius: 0.25rem;
   overflow: hidden;
 }
@@ -59,11 +60,29 @@ table th,
 table td {
   padding: 0.75rem 0.9375rem;
   text-align: left;
-  border-bottom: 0.0625rem solid var(--vscode-panel-border);
+  vertical-align: middle;
+  border-bottom: 1px solid var(--vscode-panel-border);
 }
 
 table tr:hover {
   background-color: var(--vscode-list-hoverBackground);
+}
+
+/* Checkbox column */
+th.col-select,
+td.col-select {
+  width: 2.5rem;
+  text-align: center;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+input[type="checkbox"] {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--vscode-focusBorder);
 }
 
 /* Medium screen adjustments */
@@ -99,13 +118,13 @@ table tr:hover {
   }
   
   table tr {
-    border-bottom: 0.1875rem solid var(--vscode-panel-border);
+    border-bottom: 3px solid var(--vscode-panel-border);
     display: block;
     margin-bottom: 0.625rem;
   }
-  
+
   table td {
-    border-bottom: 0.0625rem solid var(--vscode-panel-border);
+    border-bottom: 1px solid var(--vscode-panel-border);
     display: block;
     text-align: right;
     position: relative;
@@ -123,13 +142,23 @@ table tr:hover {
     color: var(--vscode-editor-foreground);
   }
   
+  td.col-select {
+    display: flex;
+    justify-content: flex-start;
+    padding-left: 0.9375rem;
+  }
+
+  td.col-select::before {
+    display: none;
+  }
+
   td[data-label="Action"] {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
     gap: 0.3125rem;
   }
-  
+
   td[data-label="Action"] button {
     flex: 0 1 auto;
     margin-right: 0;

--- a/resources/css/metadataSelectionView.css
+++ b/resources/css/metadataSelectionView.css
@@ -1,0 +1,103 @@
+/* Metadata selection view styles */
+
+.empty-state {
+    padding: 1rem 0.5rem;
+    text-align: center;
+    opacity: 0.7;
+}
+
+.empty-hint {
+    font-size: 0.85em;
+    opacity: 0.7;
+}
+
+.selection-container {
+    padding: 0.25rem 0;
+}
+
+.selection-group {
+    margin-bottom: 0.5rem;
+}
+
+.selection-group-header {
+    font-weight: bold;
+    font-size: 0.85em;
+    padding: 0.25rem 0.5rem;
+    opacity: 0.8;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.selection-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.2rem 0.5rem 0.2rem 1rem;
+}
+
+.selection-item:hover {
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+.selection-item-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.remove-item {
+    background: none;
+    border: none;
+    color: var(--vscode-icon-foreground);
+    cursor: pointer;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.75rem;
+    opacity: 0;
+    flex-shrink: 0;
+    border-radius: 0.125rem;
+}
+
+.selection-item:hover .remove-item {
+    opacity: 0.6;
+}
+
+.remove-item:hover {
+    opacity: 1 !important;
+    background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.selection-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 0.5rem;
+    border-top: 0.0625rem solid var(--vscode-panel-border);
+    margin-top: 0.25rem;
+}
+
+.action-btn {
+    padding: 0.375rem 0.5rem;
+    border: none;
+    border-radius: 0.125rem;
+    cursor: pointer;
+    font-size: var(--vscode-font-size);
+    font-family: var(--vscode-font-family);
+    color: var(--vscode-button-foreground);
+    background: var(--vscode-button-background);
+    width: 100%;
+}
+
+.action-btn:hover {
+    background: var(--vscode-button-hoverBackground);
+}
+
+.action-btn-secondary {
+    color: var(--vscode-button-secondaryForeground);
+    background: var(--vscode-button-secondaryBackground);
+}
+
+.action-btn-secondary:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}

--- a/resources/js/metadataDeploymentWebview.js
+++ b/resources/js/metadataDeploymentWebview.js
@@ -13,6 +13,57 @@ const initialize = () => {
             });
         });
     });
+
+    const selectAllCheckbox = document.getElementById("select-all");
+    if (selectAllCheckbox) {
+        selectAllCheckbox.addEventListener("change", () => {
+            const checkboxes = document.querySelectorAll(".item-checkbox");
+            checkboxes.forEach((cb) => {
+                cb.checked = selectAllCheckbox.checked;
+            });
+            postSelectionChanged();
+        });
+    }
+
+    const itemCheckboxes = document.querySelectorAll(".item-checkbox");
+    itemCheckboxes.forEach((cb) => {
+        cb.addEventListener("change", () => {
+            syncSelectAllState();
+            postSelectionChanged();
+        });
+    });
 };
+
+const syncSelectAllState = () => {
+    const selectAllCheckbox = document.getElementById("select-all");
+    if (!selectAllCheckbox) {
+        return;
+    }
+    const checkboxes = document.querySelectorAll(".item-checkbox");
+    const allChecked = checkboxes.length > 0 &&
+        Array.from(checkboxes).every((cb) => cb.checked);
+    selectAllCheckbox.checked = allChecked;
+};
+
+const postSelectionChanged = () => {
+    const checkboxes = document.querySelectorAll(".item-checkbox:checked");
+    const selectedItems = Array.from(checkboxes).map((cb) => cb.value);
+    vscode.postMessage({
+        command: "selectionChanged",
+        selectedItems: selectedItems,
+    });
+};
+
+window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.command === "updateSelections") {
+        const selected = message.selectedItems || [];
+        const checkboxes = document.querySelectorAll(".item-checkbox");
+        checkboxes.forEach((cb) => {
+            cb.checked = selected.includes(cb.value);
+        });
+        syncSelectAllState();
+    }
+});
 
 window.addEventListener("load", initialize);

--- a/resources/js/metadataSelectionView.js
+++ b/resources/js/metadataSelectionView.js
@@ -1,0 +1,37 @@
+const vscode = acquireVsCodeApi();
+
+const initialize = () => {
+    const batchRetrieveBtn = document.getElementById("batch-retrieve");
+    if (batchRetrieveBtn) {
+        batchRetrieveBtn.addEventListener("click", () => {
+            vscode.postMessage({ command: "batchRetrieve" });
+        });
+    }
+
+    const batchDeployBtn = document.getElementById("batch-deploy");
+    if (batchDeployBtn) {
+        batchDeployBtn.addEventListener("click", () => {
+            vscode.postMessage({ command: "batchDeploy" });
+        });
+    }
+
+    const clearSelectionsBtn = document.getElementById("clear-selections");
+    if (clearSelectionsBtn) {
+        clearSelectionsBtn.addEventListener("click", () => {
+            vscode.postMessage({ command: "clearSelections" });
+        });
+    }
+
+    const removeButtons = document.querySelectorAll(".remove-item");
+    removeButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+            vscode.postMessage({
+                command: "removeItem",
+                key: btn.getAttribute("data-key"),
+                item: btn.getAttribute("data-item"),
+            });
+        });
+    });
+};
+
+window.addEventListener("load", initialize);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { OrgSelectorWebview } from "./views/OrgSelectorView";
 import { MetadataSelectorView } from "./views/MetadataSelectorView";
+import { MetadataSelectionView } from "./views/MetadataSelectionView";
 import { RecordsSelectorView } from "./views/RecordsSelectorView";
 
 function checkIsSfdxProject(): boolean {
@@ -40,12 +41,17 @@ function createViewProviders(extensionContext: vscode.ExtensionContext) {
         "target"
     );
     const metadataSelectorView = new MetadataSelectorView(extensionContext);
+    const metadataSelectionView = new MetadataSelectionView(extensionContext);
     const recordsSelectorView = new RecordsSelectorView(extensionContext);
+
+    // Wire the selection view to the metadata selector
+    metadataSelectorView.setSelectionView(metadataSelectionView);
 
     return {
         sourceOrgSelector,
         targetOrgSelector,
         metadataSelectorView,
+        metadataSelectionView,
         recordsSelectorView,
     };
 }
@@ -56,6 +62,7 @@ function registerCommands(
         sourceOrgSelector: OrgSelectorWebview;
         targetOrgSelector: OrgSelectorWebview;
         metadataSelectorView: MetadataSelectorView;
+        metadataSelectionView: MetadataSelectionView;
         recordsSelectorView: RecordsSelectorView;
     }
 ) {
@@ -112,6 +119,7 @@ function registerWebviewProviders(
         sourceOrgSelector: OrgSelectorWebview;
         targetOrgSelector: OrgSelectorWebview;
         metadataSelectorView: MetadataSelectorView;
+        metadataSelectionView: MetadataSelectionView;
         recordsSelectorView: RecordsSelectorView;
     },
     commands: {
@@ -126,6 +134,7 @@ function registerWebviewProviders(
         sourceOrgSelector,
         targetOrgSelector,
         metadataSelectorView,
+        metadataSelectionView,
         recordsSelectorView,
     } = viewProviders;
     const {
@@ -148,6 +157,10 @@ function registerWebviewProviders(
         vscode.window.registerWebviewViewProvider(
             "salesforce-migrator.metadata-selector",
             metadataSelectorView
+        ),
+        vscode.window.registerWebviewViewProvider(
+            "salesforce-migrator.metadata-selection",
+            metadataSelectionView
         ),
         vscode.window.registerWebviewViewProvider(
             "salesforce-migrator.records-selector",

--- a/src/views/MetadataSelectionView.ts
+++ b/src/views/MetadataSelectionView.ts
@@ -1,0 +1,151 @@
+import * as vscode from "vscode";
+import { HtmlService } from "../services/HtmlService";
+
+export type BatchActionCallback = (
+    action: "batchRetrieve" | "batchDeploy" | "clearSelections" | "removeItem",
+    data?: { key: string; item: string }
+) => void;
+
+export class MetadataSelectionView implements vscode.WebviewViewProvider {
+    private _extensionContext: vscode.ExtensionContext;
+    private _htmlService!: HtmlService;
+    private _webviewView: vscode.WebviewView | undefined;
+    private _selectedItems: Map<string, string[]> = new Map();
+    private _onBatchAction: BatchActionCallback | undefined;
+
+    constructor(extensionContext: vscode.ExtensionContext) {
+        this._extensionContext = extensionContext;
+    }
+
+    public setOnBatchAction(callback: BatchActionCallback): void {
+        this._onBatchAction = callback;
+    }
+
+    public async resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        context: vscode.WebviewViewResolveContext,
+        token: vscode.CancellationToken
+    ): Promise<void> {
+        this._webviewView = webviewView;
+        this._htmlService = new HtmlService({
+            view: webviewView,
+            extensionUri: this._extensionContext.extensionUri,
+        });
+
+        webviewView.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [this._extensionContext.extensionUri],
+        };
+
+        this._render();
+        this._setupMessageListener(webviewView);
+    }
+
+    public updateSelections(selectedItems: Map<string, string[]>): void {
+        this._selectedItems = new Map(selectedItems);
+        this._render();
+    }
+
+    private _render(): void {
+        if (!this._webviewView) {
+            return;
+        }
+
+        this._webviewView.webview.html = this._htmlService.composeHtml({
+            body: this._composeBodyHtml(),
+            styles: ["/resources/css/metadataSelectionView.css"],
+            scripts: ["/resources/js/metadataSelectionView.js"],
+        });
+    }
+
+    private _composeBodyHtml(): string {
+        const totalCount = this._getTotalCount();
+
+        if (totalCount === 0) {
+            return `
+                <div class="empty-state">
+                    <p>No items selected.</p>
+                    <p class="empty-hint">Select items using checkboxes in the metadata deployment panel.</p>
+                </div>
+            `;
+        }
+
+        let groupsHtml = "";
+        const sortedKeys = Array.from(this._selectedItems.keys()).sort();
+
+        for (const key of sortedKeys) {
+            const items = this._selectedItems.get(key)!;
+            if (items.length === 0) {
+                continue;
+            }
+
+            const sortedItems = [...items].sort();
+
+            let itemsHtml = "";
+            for (const item of sortedItems) {
+                itemsHtml += `
+                    <div class="selection-item">
+                        <span class="selection-item-name" title="${item}">${item}</span>
+                        <button class="remove-item" data-key="${key}" data-item="${item}" title="Remove">&#10005;</button>
+                    </div>
+                `;
+            }
+
+            groupsHtml += `
+                <div class="selection-group">
+                    <div class="selection-group-header">${key}</div>
+                    ${itemsHtml}
+                </div>
+            `;
+        }
+
+        return `
+            <div class="selection-container">
+                ${groupsHtml}
+            </div>
+            <div class="selection-actions">
+                <button id="batch-retrieve" class="action-btn">Retrieve All (${totalCount})</button>
+                <button id="batch-deploy" class="action-btn">Deploy All (${totalCount})</button>
+                <button id="clear-selections" class="action-btn action-btn-secondary">Clear All</button>
+            </div>
+        `;
+    }
+
+    private _getTotalCount(): number {
+        let count = 0;
+        for (const items of this._selectedItems.values()) {
+            count += items.length;
+        }
+        return count;
+    }
+
+    private _setupMessageListener(webviewView: vscode.WebviewView): void {
+        webviewView.webview.onDidReceiveMessage(
+            (message) => {
+                if (!this._onBatchAction) {
+                    return;
+                }
+
+                switch (message.command) {
+                    case "batchRetrieve":
+                        this._onBatchAction("batchRetrieve");
+                        break;
+                    case "batchDeploy":
+                        this._onBatchAction("batchDeploy");
+                        break;
+                    case "clearSelections":
+                        this._onBatchAction("clearSelections");
+                        break;
+                    case "removeItem":
+                        this._onBatchAction("removeItem", {
+                            key: message.key,
+                            item: message.item,
+                        });
+                        break;
+                }
+            },
+            undefined,
+            this._extensionContext.subscriptions
+        );
+    }
+}


### PR DESCRIPTION
  Add checkboxes to the metadata deployment panel and a new "Selected
  Metadata" sidebar view to accumulate selections across metadata types.
  Users can select items via checkboxes, then batch retrieve or deploy
  all selected items at once. Folder-based metadata is handled
  automatically (folders are deployed before items).

  - Add checkbox column with select-all to deployment table
  - Add MetadataSelectionView sidebar showing selected items grouped by type
  - Add per-item remove and bulk clear/retrieve/deploy actions
  - Sync checkbox state when items are removed from selection view
  - Fix progress notification blocking by moving result messages outside withProgress
  - Fix table border rendering (border-collapse: separate + 1px borders)