### PR TITLE
feat: refresh metadata and records views on source org change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { OrgSelectorWebview } from "./views/OrgSelectorView";
 import { MetadataSelectorView } from "./views/MetadataSelectorView";
 import { MetadataSelectionView } from "./views/MetadataSelectionView";
 import { RecordsSelectorView } from "./views/RecordsSelectorView";
+import { OrgService } from "./services/OrgService";
 
 function checkIsSfdxProject(): boolean {
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -184,6 +185,10 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         const viewProviders = createViewProviders(extensionContext);
         const commands = registerCommands(extensionContext, viewProviders);
         registerWebviewProviders(extensionContext, viewProviders, commands);
+
+        extensionContext.subscriptions.push({
+            dispose: () => OrgService.disposeEvents(),
+        });
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(

--- a/src/views/MetadataSelectorView.ts
+++ b/src/views/MetadataSelectorView.ts
@@ -28,6 +28,9 @@ export class MetadataSelectorView implements vscode.WebviewViewProvider {
         this._orgChangeSubscription = OrgService.onSourceOrgChanged(() => {
             this._selectedItems.clear();
             this._updateSelectionView();
+            if (this._deploymentWebview) {
+                this._deploymentWebview.dispose();
+            }
             this.refreshMetadata();
         });
     }

--- a/src/views/MetadataSelectorView.ts
+++ b/src/views/MetadataSelectorView.ts
@@ -17,12 +17,19 @@ export class MetadataSelectorView implements vscode.WebviewViewProvider {
     private _metadataObjects: MetadataObject[] = [];
     private readonly _selectedItems: Map<string, string[]> = new Map();
     private _selectionView: MetadataSelectionView | undefined;
+    private readonly _orgChangeSubscription: vscode.Disposable;
 
     constructor(extensionContext: vscode.ExtensionContext) {
         this._extensionContext = extensionContext;
         this._metadataService = new MetadataService();
         this._orgService = new OrgService(extensionContext);
         this._sfCommandService = new SfCommandService();
+
+        this._orgChangeSubscription = OrgService.onSourceOrgChanged(() => {
+            this._selectedItems.clear();
+            this._updateSelectionView();
+            this.refreshMetadata();
+        });
     }
 
     public setSelectionView(selectionView: MetadataSelectionView): void {
@@ -289,6 +296,7 @@ export class MetadataSelectorView implements vscode.WebviewViewProvider {
      * Dispose the deployment webview
      */
     public dispose(): void {
+        this._orgChangeSubscription.dispose();
         if (this._deploymentWebview) {
             this._deploymentWebview = undefined;
         }

--- a/src/views/RecordsSelectorView.ts
+++ b/src/views/RecordsSelectorView.ts
@@ -11,11 +11,16 @@ export class RecordsSelectorView implements vscode.WebviewViewProvider {
     private _htmlService!: HtmlService;
     private readonly _orgService: OrgService;
     private readonly _objectService: ObjectService;
+    private readonly _orgChangeSubscription: vscode.Disposable;
 
     constructor(extensionContext: vscode.ExtensionContext) {
         this._extensionContext = extensionContext;
         this._orgService = new OrgService(extensionContext);
         this._objectService = new ObjectService();
+
+        this._orgChangeSubscription = OrgService.onSourceOrgChanged(() => {
+            this.refreshRecords();
+        });
     }
 
     public async resolveWebviewView(
@@ -208,7 +213,7 @@ export class RecordsSelectorView implements vscode.WebviewViewProvider {
      * Dispose resources
      */
     public dispose(): void {
-        // Clear references to release resources
+        this._orgChangeSubscription.dispose();
         this._exportWebview = undefined;
         this._dmlWebview = undefined;
     }

--- a/src/webviews/MetadataDeploymentWebview.ts
+++ b/src/webviews/MetadataDeploymentWebview.ts
@@ -674,6 +674,10 @@ export class MetadataDeploymentWebview {
     /**
      * Dispose all panel resources
      */
+    public dispose(): void {
+        this._disposePanel();
+    }
+
     private _disposePanel(): void {
         // Clear message listener
         this._clearMessageListener();


### PR DESCRIPTION
## Summary
- Add a static `onSourceOrgChanged` event on `OrgService` that fires when the source org is set or cleared
- `MetadataSelectorView` subscribes to the event: clears selected metadata, closes the deployment panel, and refreshes the metadata list
- `RecordsSelectorView` subscribes to the event and refreshes the custom objects list
- Event emitter disposal registered in extension subscriptions for cleanup

## Test plan
- [x] Select a source org, verify metadata and records views load
- [x] Change the source org, verify both sidebar views auto-refresh with the new org's data
- [x] Verify the deployment panel (if open) closes on org change
- [x] Verify the "Selected Metadata" accumulator view clears on org change
- [x] Clear workspace storage, verify views show the "no source org" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)