### PR TITLE
feat: add sticky search to metadata deployment view

### DIFF
--- a/resources/css/metadataDeploymentWebview.css
+++ b/resources/css/metadataDeploymentWebview.css
@@ -47,12 +47,15 @@ button:active {
     z-index: 2;
     padding: 0.75rem 0;
     background-color: var(--vscode-editor-background);
+    display: flex;
+    justify-content: center;
 }
 
 .search-wrapper {
     position: relative;
     display: flex;
     align-items: center;
+    width: 50%;
 }
 
 .search-icon {

--- a/resources/css/metadataDeploymentWebview.css
+++ b/resources/css/metadataDeploymentWebview.css
@@ -40,6 +40,77 @@ button:active {
     background: var(--vscode-button-background);
 }
 
+/* Sticky search input */
+.search-container {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 0.75rem 0;
+    background-color: var(--vscode-editor-background);
+}
+
+.search-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-icon {
+    position: absolute;
+    left: 0.5rem;
+    font-size: 0.85rem;
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+#search {
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 0.4rem 1.75rem;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    outline: none;
+    border-radius: 0.25rem;
+}
+
+#search:focus {
+    border-color: var(--vscode-focusBorder);
+}
+
+#search::placeholder {
+    color: var(--vscode-input-placeholderForeground);
+}
+
+.search-clear {
+    position: absolute;
+    right: 0.25rem;
+    background: none;
+    border: none;
+    color: var(--vscode-input-foreground);
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.375rem;
+    min-width: auto;
+    margin: 0;
+    border-radius: 0.2rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s;
+}
+
+.search-clear.visible {
+    opacity: 0.6;
+    pointer-events: auto;
+}
+
+.search-clear:hover {
+    opacity: 1;
+    background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+}
+
 /* Responsive table styles */
 table {
     width: 100%;

--- a/resources/js/metadataDeploymentWebview.js
+++ b/resources/js/metadataDeploymentWebview.js
@@ -14,6 +14,37 @@ const initialize = () => {
         });
     });
 
+    const searchInput = document.getElementById("search");
+    const clearBtn = document.getElementById("search-clear");
+
+    const filterRows = (query) => {
+        const rows = document.querySelectorAll("tbody tr");
+        rows.forEach((row) => {
+            const cells = row.querySelectorAll("td[data-label]");
+            const matches = Array.from(cells).some((cell) =>
+                cell.textContent.toLowerCase().includes(query),
+            );
+            row.style.display = matches ? "" : "none";
+        });
+    };
+
+    if (searchInput) {
+        searchInput.addEventListener("input", (e) => {
+            const query = e.target.value.toLowerCase().trim();
+            filterRows(query);
+            clearBtn.classList.toggle("visible", e.target.value.length > 0);
+        });
+    }
+
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            searchInput.value = "";
+            filterRows("");
+            clearBtn.classList.remove("visible");
+            searchInput.focus();
+        });
+    }
+
     const selectAllCheckbox = document.getElementById("select-all");
     if (selectAllCheckbox) {
         selectAllCheckbox.addEventListener("change", () => {

--- a/src/webviews/MetadataDeploymentWebview.ts
+++ b/src/webviews/MetadataDeploymentWebview.ts
@@ -175,6 +175,13 @@ export class MetadataDeploymentWebview {
         let html = "";
 
         html += `
+            <div class="search-container">
+                <div class="search-wrapper">
+                    <span class="search-icon">&#128269;</span>
+                    <input type="text" id="search" placeholder="Search..." />
+                    <button class="search-clear" id="search-clear" title="Clear search">&#10005;</button>
+                </div>
+            </div>
             <table>
                 <thead>
                     ${this._composeTableHeadHtml()}


### PR DESCRIPTION
## Summary
- Adds a sticky search input to the metadata deployment panel for filtering items
- Searches across all displayed columns (Full Name, Created By, Modified By, dates)
- Includes a search icon and a clear button with smooth transitions
- Styled with VS Code theme tokens for consistent look

## Test plan
- [x] Open a metadata type with many items
- [x] Verify the search input stays visible while scrolling
- [x] Type a query and confirm rows filter across all columns
- [x] Click the clear button and verify it resets the filter and refocuses the input
- [x] Test in both light and dark VS Code themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)