### PR TITLE
Add Proceed to DML button to records export view

### DIFF
--- a/resources/css/recordsMigration.css
+++ b/resources/css/recordsMigration.css
@@ -539,6 +539,12 @@ p {
     margin: 1rem 0;
 }
 
+/* DML proceed controls */
+#dml-operation-select {
+    width: auto;
+    min-width: 8rem;
+}
+
 /* Utils */
 .sfm-hidden {
     display: none;


### PR DESCRIPTION
## Summary
- Adds a DML operation selector (Insert/Update/Upsert/Delete) and "Proceed to DML" button next to the Export button in the records export view
- After a successful export, the controls enable and allow opening the DML view with the exported file pre-loaded
- Clicking the button before exporting shows an error message prompting the user to export first
- Extracts `_loadSourceFile()` in `RecordsMigrationDml` and adds `revealWithFile()` to support pre-loading a CSV file

🤖 Generated with [Claude Code](https://claude.com/claude-code)